### PR TITLE
Add `rotation` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ By default, the engine runs full screen and plays the life of Johnny on his isla
 
 But, if you're curious about how the engine works, you may type `jc_reborn help` and see the different options available. Feel free to try them and explore the inner workings of Screen Antics !
 
+### Command-line options
+
+`rotation <angle>`: Rotates the display. The angle can be `0` (default), `90`, `180`, or `270`.
 
 ## Current status
 

--- a/graphics.c
+++ b/graphics.c
@@ -211,7 +211,7 @@ static void grRotateAndBlitToWindow(int rotation)
                     dstOffset = ((639 - x) * windowSfc->pitch) + (y * windowSfc->format->BytesPerPixel);
                     break;
                 case 180:
-                    dstOffset = ((479 - y) * windowSfc->pitch) + ((639 - x) * windowSfc->format->BytesPerPixel);
+                    dstOffset = ((windowSfc->h - 1 - y) * windowSfc->pitch) + ((windowSfc->w - 1 - x) * windowSfc->format->BytesPerPixel);
                     break;
                 case 270:
                     dstOffset = (x * windowSfc->pitch) + ((479 - y) * windowSfc->format->BytesPerPixel);

--- a/graphics.c
+++ b/graphics.c
@@ -515,11 +515,12 @@ void grDrawSpriteFlip(SDL_Surface *sfc, struct TTtmSlot *ttmSlot, sint16 x, sint
     x += grDx; y += grDy;
 
     SDL_Surface *srcSfc = ttmSlot->sprites[imageNo][spriteNo];
+    x += srcSfc->w - 1;
 
-    for (int i=0; i < srcSfc->h; i++) {
+    for (int i=0; i < srcSfc->w; i++) {
 
-        SDL_Rect src = { 0, i, srcSfc->w, 1 };
-        SDL_Rect dest = { x, y + srcSfc->h - 1 - i, 0, 0 };
+        SDL_Rect src = { i, 0, 1, srcSfc->h };
+        SDL_Rect dest = { x - i, y, 0, 0 };
 
         SDL_BlitSurface(srcSfc, &src, sfc, &dest);
     }

--- a/graphics.h
+++ b/graphics.h
@@ -23,8 +23,8 @@
 
 #include <SDL2/SDL.h>
 
-#define SCREEN_WIDTH        640
-#define SCREEN_HEIGHT       480
+#define SCREEN_WIDTH        480
+#define SCREEN_HEIGHT       640
 
 #define MAX_BMP_SLOTS       6
 #define MAX_SPRITES_PER_BMP 120
@@ -85,6 +85,8 @@ void grToggleFullScreen();
 void grUpdateDisplay(struct TTtmThread *ttmBackgroundThread,
                      struct TTtmThread *ttmThreads,
                      struct TTtmThread *ttmHolidayThreads);
+
+static void grRotateAndBlitToWindow();
 
 SDL_Surface *grNewEmptyBackground();
 SDL_Surface *grNewLayer();

--- a/graphics.h
+++ b/graphics.h
@@ -23,8 +23,8 @@
 
 #include <SDL2/SDL.h>
 
-#define SCREEN_WIDTH        480
-#define SCREEN_HEIGHT       640
+#define SCREEN_WIDTH        640
+#define SCREEN_HEIGHT       480
 
 #define MAX_BMP_SLOTS       6
 #define MAX_SPRITES_PER_BMP 120
@@ -78,7 +78,7 @@ extern int grWindowed;
 extern int grUpdateDelay;
 
 
-void graphicsInit();
+void graphicsInit(int rotation);
 void graphicsEnd();
 void grRefreshDisplay();
 void grToggleFullScreen();

--- a/jc_reborn.c
+++ b/jc_reborn.c
@@ -43,6 +43,7 @@ static int  argTtm      = 0;
 static int  argAds      = 0;
 static int  argPlayAll  = 0;
 static int  argIsland   = 0;
+static int  argRotation = 0;
 
 static char *args[3];
 static int  numArgs  = 0;
@@ -66,6 +67,7 @@ static void usage()
         printf("         island     - display the island as background for ADS play\n");
         printf("         debug      - print some debug info on stdout\n");
         printf("         hotkeys    - enable hot keys\n");
+        printf("         rotation <angle> - rotate screen (0, 90, 180, or 270)\n");
         printf("\n");
         printf(" While-playing hot-keys (if enabled):\n");
         printf("         Esc        - Terminate immediately\n");
@@ -135,6 +137,20 @@ static void parseArgs(int argc, char **argv)
             else if (!strcmp(argv[i], "hotkeys")) {
                 evHotKeysEnabled = 1;
             }
+            else if (!strcmp(argv[i], "rotation")) {
+                if (i + 1 < argc) {
+                    int rot = atoi(argv[i + 1]);
+                    if (rot == 0 || rot == 90 || rot == 180 || rot == 270) {
+                        argRotation = rot;
+                    } else {
+                        fprintf(stderr, "error: invalid rotation angle\n");
+                        usage();
+                    }
+                    i++;
+                } else {
+                    usage();
+                }
+            }
         }
     }
 
@@ -159,7 +175,7 @@ int main(int argc, char **argv)
     parseResourceFiles("RESOURCE.MAP");
 
     if (argPlayAll) {
-        graphicsInit();
+        graphicsInit(argRotation);
         soundInit();
 
         storyPlay();
@@ -173,13 +189,13 @@ int main(int argc, char **argv)
     }
 
     else if (argBench) {
-        graphicsInit();
+        graphicsInit(argRotation);
         adsPlayBench();
         graphicsEnd();
     }
 
     else if (argTtm) {
-        graphicsInit();
+        graphicsInit(argRotation);
         soundInit();
 
         adsPlaySingleTtm(args[0]);
@@ -190,7 +206,7 @@ int main(int argc, char **argv)
 
     else if (argAds) {
 
-        graphicsInit();
+        graphicsInit(argRotation);
         soundInit();
 
         if (argIsland)


### PR DESCRIPTION
The impetus behind this fork is that I have a 2.8 inch display running on a Raspberry PI Zero W 2 that is reported as 480x640 by the driver. While I can set the rotation at the OS-level and that works fine for the command-line, the rotation is not respected by SDL2.

So, this is my solution...

We're going to write the pixels to a buffer first and handle the rotation before we render to the screen.

The command line will now support a `rotation <angle>`, with valid values of `0` (default), `90`, `180`, and `270`.

